### PR TITLE
css classes refactoring

### DIFF
--- a/src/components/PaginatedList/PaginatedList.tsx
+++ b/src/components/PaginatedList/PaginatedList.tsx
@@ -177,13 +177,15 @@ const PageNumbers = ({
 
   const handleForward = () => onPageNumberChange(currentPageState, -1);
   const handleBackWard = () => onPageNumberChange(currentPageState, 1);
+  const prevCssClasses = `${prevClass} ${controlItemClass}`
+  const nextCssClasses = `${nextClass} ${controlItemClass}`
 
   return (
     <>
       <ControlContainer className={controlClass}>
         {/* <ul className={controlClass}> */}
         {showPrev === true && (
-          <ControlItem className={[prevClass, controlItemClass]} onClick={handleForward}>
+          <ControlItem className={prevCssClasses} onClick={handleForward}>
             {prevText}
           </ControlItem>
         )}
@@ -209,7 +211,7 @@ const PageNumbers = ({
             );
           })}
         {showNext === true && (
-          <ControlItem className={[nextClass, controlItemClass]} onClick={handleBackWard}>
+          <ControlItem className={nextCssClasses} onClick={handleBackWard}>
             {nextText}
           </ControlItem>
         )}


### PR DESCRIPTION
Custom classes are concatinated with the comma. For example if I add  `nextClass = 'some-class'`
it will generate `<div class='some-class, pagination-item'></div>` and because of comma custom class will not work