### PR TITLE
fix: fixed a bug that caused onPageChange to return the previous page

### DIFF
--- a/src/components/PaginatedList/PaginatedList.tsx
+++ b/src/components/PaginatedList/PaginatedList.tsx
@@ -113,7 +113,7 @@ export const PaginatedList = <ListItem,>({
     }
     if (result < list.length / itemsPerPage && result > -1) {
       setcurrentPageState(result);
-      const pageList = getCurrentPage(list, itemsPerPage, currentPageState);
+      const pageList = getCurrentPage(list, itemsPerPage, result);
       onPageChange && onPageChange(pageList, result + 1);
     }
   };


### PR DESCRIPTION
Using the `currentPageState` immediately after using `setcurrentPageState` results in having the previous `currentPageState` used on `getCurrentPage`.  This is easily fixed by using `result` instead.

Also, you can fix it by using `useEffect` like this:
```
useEffect(() => {
    const pageList = getCurrentPage(list, itemsPerPage, currentPageState);
    onPageChange && onPageChange(pageList, currentPageState + 1);
}, [currentPageState]);
```

Hope this helps.